### PR TITLE
1 feature request copy to clipboard instead of journal page

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,21 @@
  * @author Mateusz Myalski
  */
 
+const pluginSettings = [{
+  key: "copyToClipboard",
+  default: false,
+  description: "Copy the block's children into the clipboard instead current journal page.",
+  title: "Copy block's children into the clipboard",
+  type: "boolean",
+}];
+
 function main() {
   logseq.Editor.registerBlockContextMenuItem('Shallow copy', (e) => shallowCopyBlocks(e))
 }
+
 async function shallowCopyBlocks(event) {
   try {
-    const blockUUID = event.uuid
+    const blockUUID = event.uuid;
     const parentBlockEntity = await logseq.Editor.getBlock(blockUUID);
 
     if (parentBlockEntity.children.length === 0) {
@@ -19,17 +28,54 @@ async function shallowCopyBlocks(event) {
       return;
     }
 
-    const { parentName, children } = await createBlocksBatch(parentBlockEntity);
+    if (logseq.settings.copyToClipboard) {
+      await copyToClipboard(parentBlockEntity);
+    } else {
+      await copyToJournalPage(parentBlockEntity);
+    }
 
-    const todayJournalDate = await getTodayJournalDate();
-    const journalPageEntity = await createJournalPage(todayJournalDate);
-
-    await insertBlocksIntoPage(journalPageEntity.uuid, { content: parentName, children });
-
-    showCopyToTodayJournalSuccessMessage(parentBlockEntity.children.length, todayJournalDate);
   } catch (error) {
     handleCopyError(error);
   }
+}
+
+async function copyToClipboard(blockToCopyEntity) {
+  const { stringifiedBlocks, numberOfBlocks } = await createBlocksString(blockToCopyEntity);
+
+  window.focus()
+  await navigator.clipboard.writeText(stringifiedBlocks);
+
+  showCopyToClipboardSuccessMessage(numberOfBlocks);
+}
+
+async function copyToJournalPage(blockToCopyEntity) {
+  const { parentName, children } = await createBlocksBatch(blockToCopyEntity);
+
+  const todayJournalDate = await getTodayJournalDate();
+  const journalPageEntity = await createJournalPage(todayJournalDate);
+
+  await insertBlocksIntoPage(journalPageEntity.uuid, { content: parentName, children });
+
+  showCopyToTodayJournalSuccessMessage(blockToCopyEntity.children.length, todayJournalDate);
+
+}
+
+async function createBlocksString(parentBlockEntity) {
+  let stringifiedBlocks = "";
+  let numberOfBlocks = 0;
+
+  const parentName = parentBlockEntity.content;
+  stringifiedBlocks += `- ${parentName}\n`;
+
+  const children = await Promise.all(parentBlockEntity.children.map(async (element) => {
+    const elementBlockEntity = await logseq.Editor.getBlock(element[1]);
+    numberOfBlocks += 1;
+    return elementBlockEntity.content;
+  }));
+
+  children.forEach((el) => { stringifiedBlocks += `\t- ${el}\n`; });
+
+  return { stringifiedBlocks, numberOfBlocks };
 }
 
 async function createBlocksBatch(parentBlockEntity) {
@@ -64,10 +110,14 @@ function showCopyToTodayJournalSuccessMessage(blocksCount, todayJournalDate) {
   logseq.UI.showMsg(`Copied [${blocksCount}] blocks to ${todayJournalDate}!`);
 }
 
+function showCopyToClipboardSuccessMessage(blocksCount) {
+  logseq.UI.showMsg(`Copied [${blocksCount}] blocks to the clipboard!`);
+}
+
 function handleCopyError(error) {
   console.error('Error copying blocks to journal:', error);
   logseq.UI.showMsg('An error occurred while copying blocks to journal. Check the console for details.');
 }
 
 // bootstrap
-logseq.ready(main).catch(console.error);
+logseq.useSettingsSchema(pluginSettings).ready(main).catch(console.error);

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ The Block Shallow Copy plugin empowers users with a seamless copying experience,
 - Preservation of Hierarchy: Maintain the hierarchical arrangement of content by copying not just the selected block but also its first-level children.
 - Journal Integration: Seamlessly copy blocks directly to the current journal page, streamlining the workflow and ensuring the new content is readily available in the desired location.
 - Intuitive User Interface: The plugin is designed with user-friendliness in mind, making the copying process intuitive and accessible for users of all skill levels.
+- Custom Storage Options: Choose where the copied blocks are stored - whether in today's journal page for immediate access or in the clipboard for later use, providing flexibility to adapt to your specific workflow.
 - __(TODO)__ Flexible Depth Control: While maintaining simplicity, the plugin offers control by limiting the copy to a one-level depth, striking a balance between comprehensive duplication and avoiding unnecessary complexity.
 
 ## How to Use:


### PR DESCRIPTION
Adding possibility to customize the plugin through option menu to copy blocks into clipboard instead directly to the current journal page.